### PR TITLE
Enable DSN configuration via environment.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 4.1 (unreleased)
 ----------------
 
+- Enable the possibility to get DSN from environment variables.
 
 4.0 (2023-02-02)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 4.1 (unreleased)
 ----------------
 
-- Enable the possibility to get DSN from environment variables.
+- Add support for reading the connection string from an environemt variable.
+  Use ``ENV:DB_CONN`` as connection string to look up the actual connection
+  string in the environment variable ``DB_CONN``.
 
 4.0 (2023-02-02)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 4.1 (unreleased)
 ----------------
 
-- Add support for reading the connection string from an environemt variable.
+- Add support for reading the connection string from an environment variable.
   Use ``ENV:DB_CONN`` as connection string to look up the actual connection
   string in the environment variable ``DB_CONN``.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -16,7 +16,8 @@ Edit the database connection attributes and apply any changes:
 * `Id` (read only): The database adapter ZODB ID.
 * `Title`: An optional title that shows up in the :term:`ZMI`.
 * `Database Connection String`: A string encapsulating how to connect
-  to the database.
+  to the database. It is possible to read the string from an environment
+  variable by prefixing the variable name with ``ENV`` e.g. ``ENV:DB_CONN``.
 * `Connect immediately`: Should the database connection be established
   immediately or when the first database query is run.
 * `Use Zope's internal DateTime`: Check this box to always convert PostgreSQL

--- a/src/Products/ZPsycopgDA/DA.py
+++ b/src/Products/ZPsycopgDA/DA.py
@@ -16,6 +16,7 @@
 # their work without bothering about the module dependencies.
 
 
+import os
 from operator import itemgetter
 
 from psycopg2 import DATETIME
@@ -134,7 +135,7 @@ class Connection(ConnectionBase):
 
         # TODO: let the psycopg exception propagate, or not?
         self._v_database_connection = dbf(
-            self.connection_string, self.tilevel,
+            connection_string, self.tilevel,
             self.get_type_casts(), self.encoding)
         self._v_database_connection.open()
         self._v_connected = DateTime()

--- a/src/Products/ZPsycopgDA/DA.py
+++ b/src/Products/ZPsycopgDA/DA.py
@@ -127,6 +127,10 @@ class Connection(ConnectionBase):
 
         self._v_connected = ''
         dbf = self.factory()
+        # Support reading connection string from envvar ala "ENV:DB_CONN"
+        connection_string = s
+        if connection_string.startswith("ENV:"):
+            connection_string = os.environ[connection_string[4:]]
 
         # TODO: let the psycopg exception propagate, or not?
         self._v_database_connection = dbf(

--- a/src/Products/ZPsycopgDA/tests/test_DA.py
+++ b/src/Products/ZPsycopgDA/tests/test_DA.py
@@ -111,16 +111,12 @@ class ConnectionTests(unittest.TestCase):
         with unittest.mock.patch('Products.ZPsycopgDA.DA.DB') as dbf:
             dbf.open = lambda x: None
             conn.connect('dbname=foo')
+            # assert first argument on the first call:
+            self.assertEqual(dbf.call_args_list[0][0][0], 'dbname=foo')
 
-        # assert first argument on the first call.
-        self.assertEqual(dbf.call_args_list[0][0][0], 'dbname=foo')
-
-        with unittest.mock.patch('Products.ZPsycopgDA.DA.DB') as dbf:
-            dbf.open = lambda x: None
             conn.connect('ENV:DB_CONN')
-
-        # assert first argument on the first call.
-        self.assertEqual(dbf.call_args_list[0][0][0], 'test-env-var')
+            # assert first argument on the second call:
+            self.assertEqual(dbf.call_args_list[1][0][0], 'test-env-var')
         del os.environ['DB_CONN']
 
     def test_get_type_casts(self):


### PR DESCRIPTION
A client (@sweh) uses environment variables to store the connection strings and distribute it across different instances. This patch enables the option to read the connection string from the environment variable if a prefix (`ENV:`) is used.

Would you consider this change valid? The package will be used in the future.