### PR TITLE
Ensure connection always get properly initialized.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 4.1 (unreleased)
 ----------------
 
+- Ensure connection always get properly initialized.
+
+- Add support for PostgreSQL 13.
+
 
 4.0 (2023-02-02)
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     python_requires='>=3.7',
     install_requires=[
         'setuptools',
-        'psycopg2',
+        'psycopg2 >= 2.4.2',
         'Zope >= 5',
         'Products.ZSQLMethods',
     ],

--- a/src/Products/ZPsycopgDA/db.py
+++ b/src/Products/ZPsycopgDA/db.py
@@ -61,7 +61,7 @@ class DB(TM):
     def getconn(self, init='ignored', retry=100):
         conn = pool.getconn(self.dsn)
         _pool = pool.getpool(self.dsn, create=False)
-        if not _pool._initialized[id(conn)]:
+        if id(conn) not in _pool._initialized:
             try:
                 conn.set_session(isolation_level=int(self.tilevel))
             except psycopg2.InterfaceError:
@@ -74,7 +74,7 @@ class DB(TM):
             conn.set_client_encoding(self.encoding)
             for tc in self.typecasts:
                 register_type(tc, conn)
-            _pool._initialized[id(conn)] = True
+            _pool._initialized.add(id(conn))
         return conn
 
     def putconn(self, close=False):

--- a/src/Products/ZPsycopgDA/pool.py
+++ b/src/Products/ZPsycopgDA/pool.py
@@ -45,7 +45,7 @@ class AbstractConnectionPool:
         self._used = {}
         self._rused = {}  # id(conn) -> key map
         self._keys = 0
-        self._initialized = {}
+        self._initialized = set()
 
         for i in range(self.minconn):
             self._connect()
@@ -98,8 +98,10 @@ class AbstractConnectionPool:
             self._pool.append(conn)
         else:
             conn.close()
-            if id(conn) in self._initialized:
-                del self._initialized[id(conn)]
+            try:
+                self._initialized.remove(id(conn))
+            except KeyError:
+                pass
 
         # here we check for the presence of key because it can happen that a
         # thread tries to put back a connection after a call to close
@@ -122,8 +124,10 @@ class AbstractConnectionPool:
             except Exception:
                 pass
             finally:
-                if id(conn) in self._initialized:
-                    del self._initialized[id(conn)]
+                try:
+                    self._initialized.remove(id(conn))
+                except KeyError:
+                    pass
         self.closed = True
 
 

--- a/src/Products/ZPsycopgDA/pool.py
+++ b/src/Products/ZPsycopgDA/pool.py
@@ -45,6 +45,7 @@ class AbstractConnectionPool:
         self._used = {}
         self._rused = {}  # id(conn) -> key map
         self._keys = 0
+        self._initialized = {}
 
         for i in range(self.minconn):
             self._connect()
@@ -97,6 +98,8 @@ class AbstractConnectionPool:
             self._pool.append(conn)
         else:
             conn.close()
+            if id(conn) in self._initialized:
+                del self._initialized[id(conn)]
 
         # here we check for the presence of key because it can happen that a
         # thread tries to put back a connection after a call to close
@@ -118,6 +121,9 @@ class AbstractConnectionPool:
                 conn.close()
             except Exception:
                 pass
+            finally:
+                if id(conn) in self._initialized:
+                    del self._initialized[id(conn)]
         self.closed = True
 
 
@@ -172,13 +178,13 @@ _connections_lock = threading.Lock()
 
 
 def getpool(dsn, create=True):
-    _connections_lock.acquire()
-    try:
-        if dsn not in _connections_pool and create:
-            _connections_pool[dsn] = \
-                PersistentConnectionPool(4, 200, dsn)
-    finally:
-        _connections_lock.release()
+    if create:
+        _connections_lock.acquire()
+        try:
+            if dsn not in _connections_pool:
+                _connections_pool[dsn] = PersistentConnectionPool(4, 200, dsn)
+        finally:
+            _connections_lock.release()
     return _connections_pool[dsn]
 
 


### PR DESCRIPTION
Previously it was possible that `getcursor` might get a connection which was not correctly initialized. This occurred when the last connection in the pool got closed before calling `getcursor`. As in this case the code guarded by `init` in `getconn` was not called.

Add support for PostgreSQL 13. (It now might raise `InterfaceError` exceptions)