### PR TITLE
Ensure connections always reconnect deterministically after a server disconnect (or crash).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog
 4.3 (unreleased)
 ----------------
 
+- Ensure connections always reconnect deterministically after a server
+  disconnect (or crash).
+  Previously the pool may have harboured long-running connections that only
+  got reconnected when the pool felt like returning it to the application.
+  Those connections can easily have lingered for a long time, causing
+  user-visible errors long after the original problem was fixed, e.g. when
+  the server has restarted a couple of hours ago.
+
 - Add support for Python 3.13.
 
 - Drop support for Python 3.7 and 3.8.

--- a/src/Products/ZPsycopgDA/db.py
+++ b/src/Products/ZPsycopgDA/db.py
@@ -58,25 +58,6 @@ class DB(TM):
         self.calls = 0
         self.make_mappings()
 
-    def getconn(self, init='ignored', retry=100):
-        conn = pool.getconn(self.dsn)
-        _pool = pool.getpool(self.dsn, create=False)
-        if id(conn) not in _pool._initialized:
-            try:
-                conn.set_session(isolation_level=int(self.tilevel))
-            except psycopg2.InterfaceError:
-                # we got a closed connection from a poisoned pool ->
-                # close it and retry:
-                pool.putconn(self.dsn, conn, True)
-                if retry <= 0:
-                    raise ConflictError("InterfaceError from psycopg2")
-                return self.getconn(retry=retry - 1)
-            conn.set_client_encoding(self.encoding)
-            for tc in self.typecasts:
-                register_type(tc, conn)
-            _pool._initialized.add(id(conn))
-        return conn
-
     def getconn(self, init='ignored'):
         _pool = pool.getpool(self.dsn, create=True)
 


### PR DESCRIPTION
Replaces #4 with a local branch so this can move forward.

@ctheune @sweh the unit tests are failing.